### PR TITLE
Update expected error messages for expected compile failures.

### DIFF
--- a/tests/compile-fail/fail1.stderr
+++ b/tests/compile-fail/fail1.stderr
@@ -4,7 +4,7 @@ error[E0478]: lifetime bound not satisfied
 5 |     union U<'a>: Debug = &'a str;
   |           ^^^^^
   |
-note: lifetime parameter instantiated with the lifetime `'a` as defined on the impl at 5:13
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
  --> $DIR/fail1.rs:5:13
   |
 5 |     union U<'a>: Debug = &'a str;

--- a/tests/compile-fail/fail10.stderr
+++ b/tests/compile-fail/fail10.stderr
@@ -7,4 +7,4 @@ error[E0204]: the trait `Copy` may not be implemented for this type
 7 | | }
   | |_^
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `trait_union_copy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/fail2.stderr
+++ b/tests/compile-fail/fail2.stderr
@@ -4,4 +4,4 @@ error[E0392]: parameter `'a` is never used
 5 |     union U<'a>: Debug = u8;
   |             ^^ unused parameter
   |
-  = help: consider removing `'a`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+  = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`

--- a/tests/compile-fail/fail3.stderr
+++ b/tests/compile-fail/fail3.stderr
@@ -4,4 +4,5 @@ error[E0392]: parameter `T` is never used
 5 |     union U<T>: Debug = u8;
   |             ^ unused parameter
   |
-  = help: consider removing `T`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+  = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+  = help: if you intended `T` to be a const parameter, use `const T: usize` instead

--- a/tests/compile-fail/fail5.stderr
+++ b/tests/compile-fail/fail5.stderr
@@ -2,11 +2,14 @@ error[E0277]: the trait bound `T: F` is not satisfied
  --> $DIR/fail5.rs:6:11
   |
 6 |     union U<T>: F where T: Copy+'static = T;
-  |           ^^^^  - required by this bound in `UVariant`
-  |           |
-  |           the trait `F` is not implemented for `T`
+  |           ^^^^ the trait `F` is not implemented for `T`
   |
+note: required by a bound in `UVariant`
+ --> $DIR/fail5.rs:6:17
+  |
+6 |     union U<T>: F where T: Copy+'static = T;
+  |                 ^ required by this bound in `UVariant`
 help: consider further restricting this bound
   |
 6 |     union U<T>: F where T: Copy+'static + F = T;
-  |                                         ^^^
+  |                                         +++

--- a/tests/compile-fail/fail6.stderr
+++ b/tests/compile-fail/fail6.stderr
@@ -1,7 +1,13 @@
-error[E0621]: explicit lifetime required in the type of `s`
-  --> $DIR/fail6.rs:12:13
+error[E0759]: `s` has an anonymous lifetime `'_` but it needs to satisfy a `'static` lifetime requirement
+  --> $DIR/fail6.rs:12:20
    |
 11 | fn f(s: &str) {
-   |         ---- help: add explicit lifetime `'static` to the type of `s`: `&'static str`
+   |         ---- this data with an anonymous lifetime `'_`...
 12 |     let u = U::new(s);
-   |             ^^^^^^ lifetime `'static` required
+   |                    ^ ...is used here...
+   |
+note: ...and is required to live as long as `'static` here
+  --> $DIR/fail6.rs:12:13
+   |
+12 |     let u = U::new(s);
+   |             ^^^^^^

--- a/tests/compile-fail/fail8.stderr
+++ b/tests/compile-fail/fail8.stderr
@@ -4,4 +4,12 @@ error[E0759]: `u` has lifetime `'a` but it needs to satisfy a `'static` lifetime
 11 | fn f<'a>(u: &U<'a>) {
    |             ------ this data with lifetime `'a`...
 12 |     let _: &(dyn F + 'static) = &**u;
-   |                                  ^^^ ...is captured here, requiring it to live as long as `'static`
+   |                                 -^^^
+   |                                 |
+   |                                 ...is used here...
+   |
+note: ...and is required to live as long as `'static` here
+  --> $DIR/fail8.rs:12:34
+   |
+12 |     let _: &(dyn F + 'static) = &**u;
+   |                                  ^^^

--- a/tests/compile-fail/fail9.stderr
+++ b/tests/compile-fail/fail9.stderr
@@ -6,12 +6,12 @@ error[E0308]: mismatched types
    |
    = note: expected reference `&U<'a>`
               found reference `&U<'b>`
-note: the lifetime `'a` as defined on the function body at 14:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/fail9.rs:14:6
    |
 14 | fn f<'a, 'b: 'a>(u: &U<'b>) {
    |      ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the function body at 14:10
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/fail9.rs:14:10
    |
 14 | fn f<'a, 'b: 'a>(u: &U<'b>) {


### PR DESCRIPTION
I used `TRYBUILD=overwrite cargo +nightly test` where
`cargo +nightly version` reports
`cargo 1.60.0-nightly (c08264864 2022-02-08)`.

I had to manually replace `tests/compile-fail` with `$DIR`.